### PR TITLE
Clean up Types

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,6 @@
 ## Current
 
+* Improve typings on Overrides
 ## v1.0.1
 
 * Update documentation

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export interface BaseConfiguration {
   xff?: boolean
 }
 
-export interface Configuration extends BaseConfiguration {
+export type Configuration = BaseConfiguration & {
   tokensTable?: TokenStorageEngine<TokenBucket>
   maxKeys?: number
   message?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export const handleNetmasks = (overrides: any): any => {
 }
 
 export interface Overrides {
-  [key: string]: Partial<BaseConfiguration>
+  [key: string]: BaseConfiguration
 }
 
 export interface BaseConfiguration {
@@ -46,6 +46,7 @@ export interface BaseConfiguration {
   ip?: boolean
   user?: boolean
   xff?: boolean
+  block?: any
 }
 
 export type Configuration = BaseConfiguration & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import express from 'express'
 import { TokenBucket } from './tokenBucket'
 import TokenTable, { TokenStorageEngine } from './tokenTable'
 
-declare const Set: any
 export type Maybe<T> = T | undefined
 
 export const hasValues = (
@@ -37,16 +36,23 @@ export const handleNetmasks = (overrides: any): any => {
   return overrides
 }
 
-export interface Configuration {
+export interface Overrides {
+  [key: string]: Partial<BaseConfiguration>
+}
+
+export interface BaseConfiguration {
   burst: number
   rate: number
   ip?: boolean
   user?: boolean
   xff?: boolean
-  overrides?: any
+}
+
+export interface Configuration extends BaseConfiguration {
   tokensTable?: TokenStorageEngine<TokenBucket>
   maxKeys?: number
   message?: string
+  overrides?: Overrides
 }
 
 /**


### PR DESCRIPTION
- Removes redundant Set type
- Adds specificity to Overrides
- Uses two kinds of configurations to ensure overrides are accurate